### PR TITLE
[Dark Heresy]: fix rolls for Dark Mode

### DIFF
--- a/Dark_Heresy/DarkHeresyStyle.css
+++ b/Dark_Heresy/DarkHeresyStyle.css
@@ -627,6 +627,12 @@
 	background: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Dark_Heresy/img/rolltemplate_bg.png) top left repeat;
 }
 
+@media (prefers-color-scheme: dark) {
+	.sheet-rolltemplate-dh1ed table {
+		background: none;
+	}
+}
+	
 .sheet-rolltemplate-dh1ed .sheet-rolltemplate-spacer {
 	max-width : 100%;
 	height    : auto;
@@ -673,6 +679,12 @@
 	padding-left: 10px;
 	font-size   : 15px;
 	color       : rgb(80, 80, 80);
+}
+	
+@media (prefers-color-scheme: dark) {
+	.sheet-rolltemplate-dh1ed td {
+		color: initial;
+	}
 }
 
 .sheet-rolltemplate-dh1ed td:last-child {


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Rolls in Dark Mode are unreadable due to the custom background image and font color.
This fix simply disables the problematic styles if Dark Mode is enabled. 
